### PR TITLE
[511:sparkles:] Fix OIDC IAM Provider Configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,7 @@ teardown-integration: ## teardown the Docker environment for integration testing
 .PHONY: gen-local-env-file
 gen-local-env-file: setup-integration check-integration ## generate an '.env' file for accessing the integration environment
 	@echo -e "FLASK_ENV=local\n"\
-	"OIDC_ISSUER_URL=http://localhost:8080\n"\
-	"OIDC_REALM=flask-ligand\n"\
+	"OIDC_DISCOVERY_URL=http://localhost:8080/realms/flask-ligand/.well-known/openid-configuration\n"\
 	"SQLALCHEMY_DATABASE_URI=postgresql+pg8000://admin:password@localhost:5432/app\n"\
 	"OPENAPI_GEN_SERVER_URL=http://localhost:8888" > '.env'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-flask-ligand~=0.5
+flask-ligand~=0.6

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -118,8 +118,8 @@ def basic_flask_app(
 
     # noinspection HttpUrlsUsage
     override_settings = {
-        "OIDC_ISSUER_URL": f"http://{int_testing_env_vars['KC_HOSTNAME']}:{int_testing_env_vars['KC_PORT']}",
-        "OIDC_REALM": f"{int_testing_env_vars['KC_REALM']}",
+        "OIDC_DISCOVERY_URL": f"http://{int_testing_env_vars['KC_HOSTNAME']}:{int_testing_env_vars['KC_PORT']}/"
+        f"realms/{int_testing_env_vars['KC_REALM']}/.well-known/openid-configuration",
         "SQLALCHEMY_DATABASE_URI": db_uri,
         "DB_AUTO_UPGRADE": True,
         "DB_MIGRATION_DIR": migration_directory,


### PR DESCRIPTION
The integration test suite and Makefile were updated to reflect the breaking changes introduced in flask-ligand v0.6.0.