### PR TITLE
[543:robot:] Refactor for flask-smorest Etag Changes

### DIFF
--- a/flask_ligand_example/views/pet.py
+++ b/flask_ligand_example/views/pet.py
@@ -57,8 +57,8 @@ def _we_love_pets(description: str) -> None:
 # Classes: Public
 # ======================================================================================================================
 @BLP.route("/")
+@BLP.etag
 class Pets(MethodView):
-    @BLP.etag
     @BLP.arguments(PetQueryArgsSchema, location="query")
     @BLP.response(200, PetSchema(many=True))
     @BLP.paginate(SQLCursorPage)  # noqa
@@ -69,7 +69,6 @@ class Pets(MethodView):
 
         return items
 
-    @BLP.etag
     @BLP.arguments(PetSchema)
     @BLP.response(201, PetSchema)
     @BLP.doc(security=BEARER_AUTH)
@@ -87,8 +86,8 @@ class Pets(MethodView):
 
 
 @BLP.route("/<uuid:item_id>")
+@BLP.etag
 class PetsById(MethodView):
-    @BLP.etag
     @BLP.response(200, PetSchema)
     def get(self, item_id: UUID) -> PetModel:
         """Get a pet by ID."""
@@ -97,7 +96,6 @@ class PetsById(MethodView):
 
         return item
 
-    @BLP.etag
     @BLP.arguments(PetSchema)
     @BLP.response(200, PetSchema)
     @BLP.doc(security=BEARER_AUTH)
@@ -116,7 +114,6 @@ class PetsById(MethodView):
 
         return item
 
-    @BLP.etag
     @BLP.response(204)
     @BLP.doc(security=BEARER_AUTH)
     @jwt_role_required(role="admin")

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -164,7 +164,12 @@ class TestNegativeDeletePets(object):
     """Negative DELETE test cases for the 'pets' endpoint."""
 
     def test_delete_pet_without_access_token(
-        self, app_test_client, pets_url, access_token_headers, dummy_id, dummy_etag
+        self,
+        app_test_client,
+        pets_url,
+        access_token_headers,
+        dummy_id,
+        dummy_etag,
     ):
         """
         Verify that the correct HTTP code is returned when attempting to access a protected endpoint without a JWT
@@ -176,7 +181,12 @@ class TestNegativeDeletePets(object):
             assert ret.json["message"] == "Missing Authorization Header"
 
     def test_delete_pet_with_insufficient_role(
-        self, app_test_client, pets_url, access_token_headers_no_roles, dummy_id, dummy_etag
+        self,
+        app_test_client,
+        pets_url,
+        access_token_headers_no_roles,
+        dummy_id,
+        dummy_etag,
     ):
         """
         Verify that the correct HTTP code is returned when attempting to access a protected endpoint using a JWT

--- a/tests/unit/test_basic.py
+++ b/tests/unit/test_basic.py
@@ -97,7 +97,12 @@ class TestNegativeGetPets(object):
             assert len(ret.json) == 0
 
     def test_get_pet_by_id_with_invalid_id(
-        self, primed_test_client, pets_url, access_token_headers, dummy_id, invalid_pet_id_error_msg
+        self,
+        primed_test_client,
+        pets_url,
+        access_token_headers,
+        dummy_id,
+        invalid_pet_id_error_msg,
     ):
         """Verify that the correct HTTP code is returned when an invalid ID is specified."""
 
@@ -294,7 +299,12 @@ class TestNegativeUpdatePets(object):
     # noinspection PyTestParametrized
     @pytest.mark.parametrize("default_roles", ["insufficient_role"])
     def test_update_pet_with_insufficient_role(
-        self, app_test_client, pets_url, access_token_headers, dummy_id, dummy_etag
+        self,
+        app_test_client,
+        pets_url,
+        access_token_headers,
+        dummy_id,
+        dummy_etag,
     ):
         """
         Verify that the correct HTTP code is returned when attempting to access a protected endpoint using a JWT
@@ -348,7 +358,11 @@ class TestNegativeUpdatePets(object):
             assert ret.status_code == 422
 
     def test_update_pet_with_disallowed_desc(
-        self, primed_test_client, pets_url, access_token_headers, pets_test_data_set
+        self,
+        primed_test_client,
+        pets_url,
+        access_token_headers,
+        pets_test_data_set,
     ):
         """Verify that the correct HTTP code is returned when the description contains a disallowed content."""
 
@@ -372,7 +386,12 @@ class TestNegativeUpdatePets(object):
             assert ret.status_code == 428
 
     def test_update_pet_with_invalid_etag(
-        self, primed_test_client, pets_url, access_token_headers, pets_test_data_set, dummy_etag
+        self,
+        primed_test_client,
+        pets_url,
+        access_token_headers,
+        pets_test_data_set,
+        dummy_etag,
     ):
         """
         Verify that the correct HTTP code is returned when attempting to update a pet with an invalid ETag
@@ -410,7 +429,12 @@ class TestNegativeDeletePets(object):
     """Negative DELETE test cases for the 'pets' endpoint."""
 
     def test_delete_pet_without_access_token(
-        self, app_test_client, pets_url, access_token_headers, dummy_id, dummy_etag
+        self,
+        app_test_client,
+        pets_url,
+        access_token_headers,
+        dummy_id,
+        dummy_etag,
     ):
         """
         Verify that the correct HTTP code is returned when attempting to access a protected endpoint without a JWT
@@ -424,7 +448,12 @@ class TestNegativeDeletePets(object):
     # noinspection PyTestParametrized
     @pytest.mark.parametrize("default_roles", ["user"])
     def test_delete_pet_with_insufficient_role(
-        self, app_test_client, pets_url, access_token_headers, dummy_id, dummy_etag
+        self,
+        app_test_client,
+        pets_url,
+        access_token_headers,
+        dummy_id,
+        dummy_etag,
     ):
         """
         Verify that the correct HTTP code is returned when attempting to access a protected endpoint using a JWT
@@ -479,7 +508,12 @@ class TestNegativeDeletePets(object):
             assert len(ret.json) == 3
 
     def test_update_with_invalid_etag(
-        self, primed_test_client, pets_url, access_token_headers, pets_test_data_set, dummy_etag
+        self,
+        primed_test_client,
+        pets_url,
+        access_token_headers,
+        pets_test_data_set,
+        dummy_etag,
     ):
         """
         Verify that the correct HTTP code is returned when attempting to update a pet with an invalid ETag


### PR DESCRIPTION
The 'flask-smorest' library simplified decorating Blueprint classes for Etag support. I updated tests and documentation to reflect the new approach.